### PR TITLE
Do not update via header using WebSocket protocol

### DIFF
--- a/lib/sippet/router.ex
+++ b/lib/sippet/router.ex
@@ -62,6 +62,9 @@ defmodule Sippet.Router do
   defp ip_to_string(ip) when is_binary(ip), do: ip
   defp ip_to_string(ip) when is_tuple(ip), do: :inet.ntoa(ip) |> to_string()
 
+  defp update_via(%Message{start_line: %RequestLine{}} = request, {:wss, _ip, _from_port}), do: request
+  defp update_via(%Message{start_line: %RequestLine{}} = request, {:ws, _ip, _from_port}), do: request
+
   defp update_via(%Message{start_line: %RequestLine{}} = request, {_protocol, ip, from_port}) do
     request
     |> Message.update_header_back(:via, fn


### PR DESCRIPTION
Hi @balena 
I am integrating the latest version using the WebSocket protocol and encountered a bug related to the `received` parameter. 

RFC7118 makes changes associated with the `received` parameter.
The `received` parameter is not necessary to add to the via header if the WebSocket protocol is used. Details: https://tools.ietf.org/html/rfc7118#section-5.3

As a result, the [sip.js](https://github.com/onsip/sip.js) library cannot parse a request with `received` parameter.