### PR TITLE
fix c src include

### DIFF
--- a/c_src/utils.cc
+++ b/c_src/utils.cc
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <iostream>
+#include <limits>
 
 namespace {
 


### PR DESCRIPTION
Currently it doesn't compile on Linux because of a missing include.