### PR TITLE
Fixing child_spec memory leak

### DIFF
--- a/lib/sippet.ex
+++ b/lib/sippet.ex
@@ -204,8 +204,7 @@ defmodule Sippet do
         :error ->
           raise ArgumentError, "expected :name option to be present"
       end
-
-    Supervisor.start_link(__MODULE__, options, name: :"#{name}_sup")
+    Supervisor.start_link(__MODULE__, options, name: :"#{name}_base_sup")
   end
 
   def child_spec(options) do
@@ -218,7 +217,8 @@ defmodule Sippet do
   @impl true
   def init(options) do
     children = [
-      {Registry, [name: options[:name], keys: :unique, partitions: System.schedulers_online()]}
+      {Registry, [name: options[:name], keys: :unique, partitions: System.schedulers_online()]},
+      {DynamicSupervisor, strategy: :one_for_one, name: :"#{options[:name]}_sup"}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/sippet/router.ex
+++ b/lib/sippet/router.ex
@@ -63,6 +63,7 @@ defmodule Sippet.Router do
   defp ip_to_string(ip) when is_tuple(ip), do: :inet.ntoa(ip) |> to_string()
 
   defp update_via(%Message{start_line: %RequestLine{}} = request, {:wss, _ip, _from_port}), do: request
+
   defp update_via(%Message{start_line: %RequestLine{}} = request, {:ws, _ip, _from_port}), do: request
 
   defp update_via(%Message{start_line: %RequestLine{}} = request, {_protocol, ip, from_port}) do
@@ -231,7 +232,7 @@ defmodule Sippet.Router do
 
     initial_data = Transactions.Client.State.new(outgoing_request, key, sippet)
 
-    Supervisor.start_child(
+    DynamicSupervisor.start_child(
       :"#{sippet}_sup",
       {module, [initial_data, [name: {:via, Registry, {sippet, {:transaction, key}}}]]}
     )
@@ -250,7 +251,7 @@ defmodule Sippet.Router do
 
     initial_data = Transactions.Server.State.new(incoming_request, key, sippet)
 
-    Supervisor.start_child(
+    DynamicSupervisor.start_child(
       :"#{sippet}_sup",
       {module, [initial_data, [name: {:via, Registry, {sippet, {:transaction, key}}}]]}
     )


### PR DESCRIPTION
I fixed a memory leak where the child_specs of a supervisor do not get cleaned. In order to do so automatically, we should use a DynamicSupervisor. Fixes #26 . 