### PR TITLE
Remove static genserver name from UDP transport

### DIFF
--- a/lib/sippet/transports/udp.ex
+++ b/lib/sippet/transports/udp.ex
@@ -76,7 +76,7 @@ defmodule Sippet.Transports.UDP do
                 ":address contains an invalid IP or DNS name, got: #{inspect(reason)}"
       end
 
-    GenServer.start_link(__MODULE__, {name, ip, port, family}, name: __MODULE__)
+    GenServer.start_link(__MODULE__, {name, ip, port, family})
   end
 
   @impl true


### PR DESCRIPTION
Transports are reached via Registry, so there's no need to
use a static GenServer name, which in addition forces
only one transport listener for erlang app.
Removing it allows to listen on different ports and start
different Cores.