### PR TITLE
Add support for Event header.

### DIFF
--- a/lib/sippet/message.ex
+++ b/lib/sippet/message.ex
@@ -1413,6 +1413,7 @@ defmodule Sippet.Message do
         :cseq -> {"CSeq", true}
         :date -> {"Date", true}
         :error_info -> {"Error-Info", true}
+        :event -> {"Event", true}
         :expires -> {"Expires", true}
         :from -> {"From", true}
         :in_reply_to -> {"In-Reply-To", true}


### PR DESCRIPTION
In addition, RFC states that there MUST be exactly one event type listed
per event header.  Multiple events per message are disallowed.