### PR TITLE
Add missing cstdint

### DIFF
--- a/c_src/utils.h
+++ b/c_src/utils.h
@@ -12,6 +12,7 @@
 #define UTILS_H_
 
 #include <string>
+#include <cstdint>
 
 #include "string_tokenizer.h"
 


### PR DESCRIPTION
Hi, when trying to compile on Arch I am getting

```
g++ -O3 -std=c++11 -finline-functions -fstack-protector -Wall -fPIC -I /home/michal/.asdf/installs/erlang/26.2.1/erts-14.2.1/include -I /home/michal/.asdf/installs/erlang/26.2.1/usr/include  -c -o /home/michal/Repos/elixir-sippet/c_src/utils.o /home/michal/Repos/elixir-sippet/c_src/utils.cc
/home/michal/Repos/elixir-sippet/c_src/utils.cc:25:31: error: ‘uint8_t’ has not been declared
   25 |   static bool Convert(CHAR c, uint8_t* digit) {
      |                               ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc: In static member function ‘static bool {anonymous}::BaseCharToDigit<CHAR, BASE, true>::Convert(CHAR, int*)’:
/home/michal/Repos/elixir-sippet/c_src/utils.cc:27:28: error: ‘uint8_t’ does not name a type
   27 |       *digit = static_cast<uint8_t>(c - '0');
      |                            ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:15:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   14 | #include <limits>
  +++ |+#include <cstdint>
   15 | 
/home/michal/Repos/elixir-sippet/c_src/utils.cc: At global scope:
/home/michal/Repos/elixir-sippet/c_src/utils.cc:37:31: error: ‘uint8_t’ has not been declared
   37 |   static bool Convert(CHAR c, uint8_t* digit) {
      |                               ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:52:26: error: ‘uint8_t’ has not been declared
   52 | bool CharToDigit(CHAR c, uint8_t* digit) {
      |                          ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:164:49: error: ‘uint8_t’ has not been declared
  164 |     static bool CheckBounds(value_type* output, uint8_t new_digit) {
      |                                                 ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:173:27: error: ‘uint8_t’ has not been declared
  173 |     static void Increment(uint8_t increment, value_type* output) {
      |                           ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:180:49: error: ‘uint8_t’ has not been declared
  180 |     static bool CheckBounds(value_type* output, uint8_t new_digit) {
      |                                                 ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:189:27: error: ‘uint8_t’ has not been declared
  189 |     static void Increment(uint8_t increment, value_type* output) {
      |                           ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc: In static member function ‘static bool {anonymous}::IteratorRangeToNumber<IteratorRangeToNumberTraits>::Base<Sign>::Invoke({anonymous}::IteratorRangeToNumber<IteratorRangeToNumberTraits>::const_iterator, {anonymous}::IteratorRangeToNumber<IteratorRangeToNumberTraits>::const_iterator, typename {anonymous}::IteratorRangeToNumber<IteratorRangeToNumberTraits>::traits::value_type*)’:
/home/michal/Repos/elixir-sippet/c_src/utils.cc:143:9: error: ‘uint8_t’ was not declared in this scope
  143 |         uint8_t new_digit = 0;
      |         ^~~~~~~
/home/michal/Repos/elixir-sippet/c_src/utils.cc:143:9: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/michal/Repos/elixir-sippet/c_src/utils.cc:145:52: error: ‘new_digit’ was not declared in this scope; did you mean ‘iswxdigit’?
  145 |         if (!CharToDigit<traits::kBase>(*current, &new_digit)) {
      |                                                    ^~~~~~~~~
      |                                                    iswxdigit
/home/michal/Repos/elixir-sippet/c_src/utils.cc:150:42: error: ‘new_digit’ was not declared in this scope; did you mean ‘iswxdigit’?
  150 |           if (!Sign::CheckBounds(output, new_digit)) {
      |                                          ^~~~~~~~~
      |                                          iswxdigit
/home/michal/Repos/elixir-sippet/c_src/utils.cc:156:25: error: ‘new_digit’ was not declared in this scope; did you mean ‘iswxdigit’?
  156 |         Sign::Increment(new_digit, output);
      |                         ^~~~~~~~~
      |                         iswxdigit
make: *** [Makefile:137: /home/michal/Repos/elixir-sippet/c_src/utils.o] Error 1
** (Mix) Could not compile with "make" (exit status: 2).
You need to have gcc and make installed. If you are using
Ubuntu or any other Debian-based system, install the packages
"build-essential". Also install "erlang-dev" package if not
included in your Erlang/OTP version. If you're on Fedora, run
"dnf group install 'Development Tools'".
```

Looks like adding `cstdint` solves the problem