### PR TITLE
Fix nif build for macOS

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -103,7 +103,13 @@ ifeq ($(shell expr $(ERL_VERSION) \>= 23), 1)
 else
 	LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lerl_interface
 endif
-LDFLAGS += -bundle -bundle_loader $(ERL_ROOT)/erts-*/bin/beam.smp -lstdc++
+
+ifeq ($(PLATFORM),darwin)
+	LDFLAGS += -bundle -bundle_loader $(ERL_ROOT)/erts-*/bin/beam.smp
+else
+	LDFLAGS += -shared
+endif
+LDFLAGS += -lstdc++
 
 # Verbosity.
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,6 +8,7 @@ PROJECT := sippet_nif
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
 ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERL_ROOT ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:root_dir()]).")
 ERL_VERSION := $(shell erl -noshell -eval 'io:fwrite("~s\n", [erlang:system_info(otp_release)]).' -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)
@@ -102,7 +103,7 @@ ifeq ($(shell expr $(ERL_VERSION) \>= 23), 1)
 else
 	LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lerl_interface
 endif
-LDFLAGS += -shared -lstdc++
+LDFLAGS += -bundle -bundle_loader $(ERL_ROOT)/erts-*/bin/beam.smp -lstdc++
 
 # Verbosity.
 


### PR DESCRIPTION
My computer has the following specs:

Model Name: MacBook Pro
Model Identifier: MacBookPro18,4
Chip: Apple M1 Max
System Version: macOS 15.6.1 (24G90)
Kernel Version: Darwin 24.6.0

When building on my machine, I was getting the following errors:

```
/usr/bin/clang -I/opt/homebrew/opt/unixodbc/include /Users/dennisbeatty/Code/sip_proxy/deps/sippet/c_src/string_piece.o /Users/dennisbeatty/Code/sip_proxy/deps/sippet/c_src/utils.o /Users/dennisbeatty/Code/sip_proxy/deps/sippet/c_src/parser.o /Users/dennisbeatty/Code/sip_proxy/deps/sippet/c_src/tokenizer.o /Users/dennisbeatty/Code/sip_proxy/deps/sippet/c_src/prtime.o -L/opt/homebrew/opt/unixodbc/lib -shared -lstdc++ -L /Users/dennisbeatty/.local/share/mise/installs/erlang/28.0.2/usr/lib -lei -o /Users/dennisbeatty/Code/sip_proxy/deps/sippet/priv/sippet_nif.so
Undefined symbols for architecture arm64:
  "_enif_alloc_binary", referenced from:
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseStarOrMultipleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseCseq(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseTrimmedUtf8(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_get_list_cell", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_get_map_value", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_get_tuple", referenced from:
      (anonymous namespace)::ParseSingleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleVias(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_inspect_binary", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_is_atom", referenced from:
      (anonymous namespace)::ParseMultipleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokenParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokens(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_is_binary", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_is_list", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_make_atom", referenced from:
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      _on_load in parser.o
      ...
  "_enif_make_badarg", referenced from:
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
  "_enif_make_binary", referenced from:
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseStarOrMultipleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseCseq(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseTrimmedUtf8(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_make_double", referenced from:
      (anonymous namespace)::ParseTimestamp(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseTimestamp(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
  "_enif_make_existing_atom_len", referenced from:
      (anonymous namespace)::MakeLowerCaseExistingAtom(enif_environment_t*, StringPiece, unsigned long*) in parser.o
  "_enif_make_int", referenced from:
      (anonymous namespace)::ParseSingleInteger(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseCseq(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseDate(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_make_list", referenced from:
      (anonymous namespace)::ParseMultipleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokenParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokens(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleVias(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_make_list_cell", referenced from:
      (anonymous namespace)::ParseMultipleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokenParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokens(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleVias(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleWarnings(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_make_map_put", referenced from:
      (anonymous namespace)::ParseParameters(enif_environment_t*, Tokenizer*) in parser.o
      (anonymous namespace)::ParseAuthParams(enif_environment_t*, Tokenizer*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      ...
  "_enif_make_new_map", referenced from:
      (anonymous namespace)::ParseRetryAfter(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseParameters(enif_environment_t*, Tokenizer*) in parser.o
      (anonymous namespace)::ParseAuthParams(enif_environment_t*, Tokenizer*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      parse_wrapper(enif_environment_t*, int, unsigned long const*) in parser.o
      ...
  "_enif_make_reverse_list", referenced from:
      (anonymous namespace)::ParseMultipleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokenParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleTokens(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleContactParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleVias(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseMultipleWarnings(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
  "_enif_make_tuple", referenced from:
      (anonymous namespace)::ParseMultipleUriParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSchemeAndAuthParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleTokenParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseSingleTypeSubtypeParams(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      (anonymous namespace)::ParseCseq(enif_environment_t*, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in parser.o
      ...
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [/Users/dennisbeatty/Code/sip_proxy/deps/sippet/priv/sippet_nif.so] Error 1
could not compile dependency :sippet, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile sippet --force", update it with "mix deps.update sippet" or clean it with "mix deps.clean sippet"
```

After following the recommendations in [this thread](https://elixirforum.com/t/undefined-error-of-enif-make-string-happens-to-erlang-nif-function/47053/3), I was able to build as expected. This brings those changes into sippet for others using macOS.