### PR TITLE
fix charlist warning

### DIFF
--- a/lib/sippet/parser.ex
+++ b/lib/sippet/parser.ex
@@ -13,7 +13,7 @@ defmodule Sippet.Parser do
   Initializes and loads the C++ NIF module.
   """
   def init() do
-    path = :filename.join(:code.priv_dir(unquote(app)), 'sippet_nif')
+    path = :filename.join(:code.priv_dir(unquote(app)), ~c'sippet_nif')
     :ok = :erlang.load_nif(path, 0)
   end
 


### PR DESCRIPTION
Compiling the project produces this warning for using a single quoted string to produce a charlist:

```
    warning: using single-quoted strings to represent charlists is deprecated.
    Use ~c"" if you indeed want a charlist or use "" instead.
    You may run "mix format --migrate" to change all single-quoted
    strings to use the ~c sigil and fix this warning.
    │
 16 │     path = :filename.join(:code.priv_dir(unquote(app)), 'sippet_nif')
    │                                                         ~
    │
    └─ lib/sippet/parser.ex:16:57
```

This change updates the code to use the `~c` sigil to fix the warning.